### PR TITLE
feature/when suggesting usernames skip input that consist from disallowed characters

### DIFF
--- a/app/models/discourse_single_sign_on.rb
+++ b/app/models/discourse_single_sign_on.rb
@@ -373,12 +373,9 @@ class DiscourseSingleSignOn < SingleSignOn
   end
 
   def resolve_username
-    username_suggester_input = username.presence || name.presence
-    if SiteSetting.use_email_for_username_and_name_suggestions
-      username_suggester_input = username_suggester_input || email
-    end
-
-    UserNameSuggester.suggest(username_suggester_input)
+    suggester_input = [username, name]
+    suggester_input << email if SiteSetting.use_email_for_username_and_name_suggestions
+    UserNameSuggester.suggest_username(suggester_input)
   end
 
   def resolve_name

--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -189,7 +189,7 @@ class Auth::Result
   end
 
   def username_suggester_attributes
-    username || name || email
+    [username, name, email]
   end
 
   def authenticator
@@ -203,6 +203,6 @@ class Auth::Result
       end
     end
 
-    UserNameSuggester.suggest(username_suggester_attributes)
+    UserNameSuggester.suggest_username(username_suggester_attributes)
   end
 end

--- a/lib/user_name_suggester.rb
+++ b/lib/user_name_suggester.rb
@@ -4,10 +4,22 @@ module UserNameSuggester
   GENERIC_NAMES = ['i', 'me', 'info', 'support', 'admin', 'webmaster', 'hello', 'mail', 'office', 'contact', 'team']
   LAST_RESORT_USERNAME = "user"
 
-  def self.suggest(name_or_email,  current_username = nil)
-    name = parse_name_from_email(name_or_email)
+  def self.suggest_username(input,  current_username = nil)
+    name = input.find do |item|
+      parsed_name = parse_name_from_email(item)
+      break parsed_name if sanitize_username(parsed_name).present?
+    end
+
     name = fix_username(name)
     find_available_username_based_on(name, current_username)
+  end
+
+  # this method will be deleted, use suggest_username() instead
+  # the only difference between suggest_username() and suggest()
+  # is that suggest_username() takes an array of input strings as the first
+  # parameter, when suggest() takes only one input string
+  def self.suggest(name_or_email,  current_username = nil)
+    suggest_username([name_or_email], current_username)
   end
 
   def self.parse_name_from_email(name_or_email)

--- a/spec/components/user_name_suggester_spec.rb
+++ b/spec/components/user_name_suggester_spec.rb
@@ -4,13 +4,13 @@ require 'rails_helper'
 require 'user_name_suggester'
 
 describe UserNameSuggester do
-  describe '.suggest' do
-    before do
-      SiteSetting.min_username_length = 3
-      SiteSetting.max_username_length = 15
-      SiteSetting.reserved_usernames = ''
-    end
+  before do
+    SiteSetting.min_username_length = 3
+    SiteSetting.max_username_length = 15
+    SiteSetting.reserved_usernames = ''
+  end
 
+  describe '.suggest' do
     it "keeps adding numbers to the username" do
       Fabricate(:user, username: 'sam')
       Fabricate(:user, username: 'sAm1')
@@ -199,6 +199,26 @@ describe UserNameSuggester do
         SiteSetting.allowed_unicode_username_characters = "[য়া]"
         expect(UserNameSuggester.suggest('aয়াb鳥c')).to eq('aয়াb_c')
       end
+    end
+  end
+
+  describe '.suggest_username' do
+    it "skips input made entirely of disallowed characters" do
+      SiteSetting.unicode_usernames = false
+
+      input = %w[Πλάτων علي William]
+      suggestion = UserNameSuggester.suggest_username(input)
+
+      expect(suggestion).to eq "William"
+    end
+
+    it "uses the first item if it isn't made entirely of disallowed characters  " do
+      SiteSetting.unicode_usernames = false
+
+      input = %w[William علي Πλάτων]
+      suggestion = UserNameSuggester.suggest_username(input)
+
+      expect(suggestion).to eq "William"
     end
   end
 end

--- a/spec/models/discourse_single_sign_on_spec.rb
+++ b/spec/models/discourse_single_sign_on_spec.rb
@@ -438,6 +438,20 @@ describe DiscourseSingleSignOn do
     expect(user.username).to eq "John_Smith"
   end
 
+  it "uses name for username suggestions if username consists entirely of disallowed characters" do
+    SiteSetting.unicode_usernames = false
+
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.username = "Πλάτων"
+    sso.name = "Plato"
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.username).to eq sso.name
+  end
+
   it "doesn't use email as a source for username suggestions by default" do
     sso = new_discourse_sso
     sso.external_id = "100"
@@ -451,7 +465,7 @@ describe DiscourseSingleSignOn do
     expect(user.username).to eq I18n.t('fallback_username')
   end
 
-  it "use email as a source for username suggestions if enabled" do
+  it "uses email as a source for username suggestions if enabled" do
     SiteSetting.use_email_for_username_and_name_suggestions = true
     sso = new_discourse_sso
     sso.external_id = "100"
@@ -478,7 +492,7 @@ describe DiscourseSingleSignOn do
     expect(user.name).to eq ""
   end
 
-  it "use email as a source for name suggestions if enabled" do
+  it "uses email as a source for name suggestions if enabled" do
     SiteSetting.use_email_for_username_and_name_suggestions = true
     sso = new_discourse_sso
     sso.external_id = "100"
@@ -490,6 +504,21 @@ describe DiscourseSingleSignOn do
 
     user = sso.lookup_or_create_user(ip_address)
     expect(user.name).to eq "Mail"
+  end
+
+  it "uses email for username suggestions if username and name consist entirely of disallowed characters" do
+    SiteSetting.use_email_for_username_and_name_suggestions = true
+    SiteSetting.unicode_usernames = false
+
+    sso = new_discourse_sso
+    sso.external_id = "100"
+
+    sso.username = "Πλάτων"
+    sso.name = "Πλάτων"
+    sso.email = "mail@mail.com"
+    user = sso.lookup_or_create_user(ip_address)
+
+    expect(user.username).to eq "mail"
   end
 
   it "can override username with a number at the end to a simpler username without a number" do


### PR DESCRIPTION
- Implement a new method in UsernameSuggester
- Fix Discourse Connect
- Fix external auth
