### PR TITLE
FEATURE: in Authenticators don't use email for username suggestions until enabled in settings

### DIFF
--- a/lib/auth/result.rb
+++ b/lib/auth/result.rb
@@ -196,7 +196,9 @@ class Auth::Result
   end
 
   def username_suggester_attributes
-    [username, name, email]
+    attributes = [username, name]
+    attributes << email if SiteSetting.use_email_for_username_and_name_suggestions
+    attributes
   end
 
   def authenticator

--- a/spec/requests/omniauth_callbacks_controller_spec.rb
+++ b/spec/requests/omniauth_callbacks_controller_spec.rb
@@ -241,6 +241,31 @@ RSpec.describe Users::OmniauthCallbacksController do
         expect(data["associate_url"]).to eq(nil)
       end
 
+      it 'does not use email for username suggestions by default' do
+        username = ""
+        name = ""
+        email = "billmailbox@test.com"
+        mock_auth(email, username, name)
+
+        get "/auth/google_oauth2/callback.json"
+        data = JSON.parse(cookies[:authentication_data])
+
+        expect(data["username"]).to eq("user1") # not "billmailbox" that can be extracted from email
+      end
+
+      it 'uses email for username suggestions if enabled in settings' do
+        SiteSetting.use_email_for_username_and_name_suggestions = true
+        username = ""
+        name = ""
+        email = "billmailbox@test.com"
+        mock_auth(email, username, name)
+
+        get "/auth/google_oauth2/callback.json"
+        data = JSON.parse(cookies[:authentication_data])
+
+        expect(data["username"]).to eq("billmailbox")
+      end
+
       describe 'when site is invite_only' do
         before do
           SiteSetting.invite_only = true


### PR DESCRIPTION
…ntil enabled in settings

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
