### PR TITLE
TESTS dev/setting up emoji picker placement

### DIFF
--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -38,6 +38,7 @@ export default Component.extend({
   hoveredEmoji: null,
   isActive: false,
   usePopper: true,
+  placement: "auto", // one of popper.js' placements, see https://popper.js.org/docs/v2/constructors/#options
   initialFilter: "",
 
   init() {
@@ -111,7 +112,10 @@ export default Component.extend({
           },
         ];
 
-        if (window.innerWidth < popperAnchor.clientWidth * 2) {
+        if (
+          this.placement === "auto" &&
+          window.innerWidth < popperAnchor.clientWidth * 2
+        ) {
           modifiers.push({
             name: "computeStyles",
             enabled: true,
@@ -130,7 +134,7 @@ export default Component.extend({
         }
 
         this._popper = createPopper(popperAnchor, emojiPicker, {
-          placement: "auto",
+          placement: this.placement,
         });
       }
 

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -96,11 +96,9 @@ export default Component.extend({
         return;
       }
 
-      const textareaWrapper = document.querySelector(
-        ".d-editor-textarea-wrapper"
-      );
+      const popperAnchor = this._getPopperAnchor();
 
-      if (!this.site.isMobileDevice && this.usePopper && textareaWrapper) {
+      if (!this.site.isMobileDevice && this.usePopper && popperAnchor) {
         const modifiers = [
           {
             name: "preventOverflow",
@@ -113,7 +111,7 @@ export default Component.extend({
           },
         ];
 
-        if (window.innerWidth < textareaWrapper.clientWidth * 2) {
+        if (window.innerWidth < popperAnchor.clientWidth * 2) {
           modifiers.push({
             name: "computeStyles",
             enabled: true,
@@ -131,9 +129,8 @@ export default Component.extend({
           });
         }
 
-        this._popper = createPopper(textareaWrapper, emojiPicker, {
+        this._popper = createPopper(popperAnchor, emojiPicker, {
           placement: "auto",
-          modifiers,
         });
       }
 
@@ -336,6 +333,10 @@ export default Component.extend({
       },
       { threshold: 1 }
     );
+  },
+
+  _getPopperAnchor() {
+    return document.querySelector(".d-editor-textarea-wrapper");
   },
 
   @bind

--- a/app/assets/javascripts/discourse/app/components/emoji-picker.js
+++ b/app/assets/javascripts/discourse/app/components/emoji-picker.js
@@ -336,7 +336,12 @@ export default Component.extend({
   },
 
   _getPopperAnchor() {
-    return document.querySelector(".d-editor-textarea-wrapper");
+    // .d-editor-textarea-wrapper is only for backward compatibility here
+    // in new code use .emoji-picker-anchor
+    return (
+      document.querySelector(".emoji-picker-anchor") ??
+      document.querySelector(".d-editor-textarea-wrapper")
+    );
   },
 
   @bind


### PR DESCRIPTION
- EMOJI-SELECTOR: exctract the _getPopperAnchor function
- EMOJI-SELECTOR: use .emoji-picker-anchor as a popper anchor
- EMOJI-SELECTOR: make it possible to set up emoji-picker popper position

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
