### PR TITLE
test --- feature/auto remove status after predefined period

### DIFF
--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -238,9 +238,9 @@ const SiteHeaderComponent = MountWidget.extend(
 
       this.appEvents.on("dom:clean", this, "_cleanDom");
 
-      this.appEvents.on("current-user-status:changed", () =>
-        this.queueRerender()
-      );
+      if (this.currentUser) {
+        this.currentUser.on("status-changed", () => this.queueRerender());
+      }
 
       if (
         this.currentUser &&

--- a/app/assets/javascripts/discourse/app/components/site-header.js
+++ b/app/assets/javascripts/discourse/app/components/site-header.js
@@ -238,7 +238,9 @@ const SiteHeaderComponent = MountWidget.extend(
 
       this.appEvents.on("dom:clean", this, "_cleanDom");
 
-      this.appEvents.on("user-status:changed", () => this.queueRerender());
+      this.appEvents.on("current-user-status:changed", () =>
+        this.queueRerender()
+      );
 
       if (
         this.currentUser &&

--- a/app/assets/javascripts/discourse/app/components/user-card-contents.js
+++ b/app/assets/javascripts/discourse/app/components/user-card-contents.js
@@ -196,6 +196,7 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
           );
         }
         this.setProperties({ user });
+        this.user.trackStatus();
         return user;
       })
       .catch(() => this._close())
@@ -203,6 +204,10 @@ export default Component.extend(CardContentsBase, CanCheckEmails, CleansUp, {
   },
 
   _close() {
+    if (this.user) {
+      this.user.stopTrackingStatus();
+    }
+
     this.setProperties({
       user: null,
       topicPostCount: null,

--- a/app/assets/javascripts/discourse/app/controllers/user-status.js
+++ b/app/assets/javascripts/discourse/app/controllers/user-status.js
@@ -5,26 +5,59 @@ import { inject as service } from "@ember/service";
 import { popupAjaxError } from "discourse/lib/ajax-error";
 import bootbox from "bootbox";
 import discourseComputed from "discourse-common/utils/decorators";
+import ItsATrap from "@discourse/itsatrap";
+import {
+  TIME_SHORTCUT_TYPES,
+  timeShortcuts,
+} from "discourse/lib/time-shortcut";
 
 export default Controller.extend(ModalFunctionality, {
   userStatusService: service("user-status"),
 
   emoji: null,
   description: null,
+  endsAt: null,
+
   showDeleteButton: false,
+  prefilledDateTime: null,
+  timeShortcuts: null,
+  _itsatrap: null,
 
   onShow() {
     const status = this.currentUser.status;
     this.setProperties({
       emoji: status?.emoji,
       description: status?.description,
+      endsAt: status?.ends_at,
       showDeleteButton: !!status,
+      timeShortcuts: this._buildTimeShortcuts(),
+      prefilledDateTime: status?.ends_at,
     });
+
+    this.set("_itsatrap", new ItsATrap());
+  },
+
+  onClose() {
+    this._itsatrap.destroy();
+    this.set("_itsatrap", null);
+    this.set("timeShortcuts", null);
   },
 
   @discourseComputed("emoji", "description")
   statusIsSet(emoji, description) {
     return !!emoji && !!description;
+  },
+
+  @discourseComputed
+  customTimeShortcutLabels() {
+    const labels = {};
+    labels[TIME_SHORTCUT_TYPES.NONE] = "time_shortcut.never";
+    return labels;
+  },
+
+  @discourseComputed
+  hiddenTimeShortcutOptions() {
+    return [TIME_SHORTCUT_TYPES.LAST_CUSTOM];
   },
 
   @action
@@ -36,8 +69,17 @@ export default Controller.extend(ModalFunctionality, {
   },
 
   @action
+  onTimeSelected(_, time) {
+    this.set("endsAt", time);
+  },
+
+  @action
   saveAndClose() {
-    const status = { description: this.description, emoji: this.emoji };
+    const status = {
+      description: this.description,
+      emoji: this.emoji,
+      ends_at: this.endsAt?.toISOString(),
+    };
     this.userStatusService
       .set(status)
       .then(() => {
@@ -52,5 +94,11 @@ export default Controller.extend(ModalFunctionality, {
     } else {
       popupAjaxError(e);
     }
+  },
+
+  _buildTimeShortcuts() {
+    const timezone = this.currentUser.timezone;
+    const shortcuts = timeShortcuts(timezone);
+    return [shortcuts.oneHour(), shortcuts.twoHours(), shortcuts.tomorrow()];
   },
 });

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -117,8 +117,7 @@ export default {
       });
 
       bus.subscribe(`/user-status/${user.id}`, (data) => {
-        user.set("status", data);
-        appEvents.trigger("current-user-status:changed");
+        appEvents.trigger("current-user-status:changed", data);
       });
 
       const site = container.lookup("site:main");

--- a/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
+++ b/app/assets/javascripts/discourse/app/initializers/subscribe-user-notifications.js
@@ -118,7 +118,7 @@ export default {
 
       bus.subscribe(`/user-status/${user.id}`, (data) => {
         user.set("status", data);
-        appEvents.trigger("user-status:changed");
+        appEvents.trigger("current-user-status:changed");
       });
 
       const site = container.lookup("site:main");

--- a/app/assets/javascripts/discourse/app/lib/time-shortcut.js
+++ b/app/assets/javascripts/discourse/app/lib/time-shortcut.js
@@ -11,6 +11,7 @@ import {
   nextBusinessWeekStart,
   nextMonth,
   now,
+  oneHour,
   oneYear,
   sixMonths,
   thisWeekend,
@@ -18,12 +19,15 @@ import {
   threeMonths,
   tomorrow,
   twoDays,
+  twoHours,
   twoMonths,
   twoWeeks,
 } from "discourse/lib/time-utils";
 import I18n from "I18n";
 
 export const TIME_SHORTCUT_TYPES = {
+  ONE_HOUR: "one_hour",
+  TWO_HOURS: "two_hours",
   LATER_TODAY: "later_today",
   TOMORROW: "tomorrow",
   THIS_WEEKEND: "this_weekend",
@@ -77,6 +81,24 @@ export function specialShortcutOptions() {
 
 export function timeShortcuts(timezone) {
   return {
+    oneHour() {
+      return {
+        id: TIME_SHORTCUT_TYPES.ONE_HOUR,
+        icon: "angle-right",
+        label: "time_shortcut.in_one_hour",
+        time: oneHour(timezone),
+        timeFormatKey: "dates.time",
+      };
+    },
+    twoHours() {
+      return {
+        id: TIME_SHORTCUT_TYPES.TWO_HOURS,
+        icon: "angle-right",
+        label: "time_shortcut.in_two_hours",
+        time: twoHours(timezone),
+        timeFormatKey: "dates.time",
+      };
+    },
     laterToday() {
       return {
         id: TIME_SHORTCUT_TYPES.LATER_TODAY,

--- a/app/assets/javascripts/discourse/app/lib/time-utils.js
+++ b/app/assets/javascripts/discourse/app/lib/time-utils.js
@@ -19,6 +19,14 @@ export function startOfDay(momentDate, startOfDayHour = START_OF_DAY_HOUR) {
   return momentDate.hour(startOfDayHour).startOf("hour");
 }
 
+export function oneHour(timezone) {
+  return now(timezone).add(1, "hours");
+}
+
+export function twoHours(timezone) {
+  return now(timezone).add(2, "hours");
+}
+
 export function tomorrow(timezone) {
   return startOfDay(now(timezone).add(1, "day"));
 }

--- a/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
+++ b/app/assets/javascripts/discourse/app/templates/components/user-card-contents.hbs
@@ -63,7 +63,11 @@
             <h2 class="staged">{{i18n "user.staged"}}</h2>
           {{/if}}
           {{#if this.hasStatus}}
-            <h3 class="user-status">{{html-safe this.userStatusEmoji}} {{this.user.status.description}}</h3>
+            <h3 class="user-status">
+              {{html-safe this.userStatusEmoji}}
+              {{this.user.status.description}}
+              {{format-date this.user.status.ends_at format="tiny"}}
+            </h3>
           {{/if}}
           {{plugin-outlet name="user-card-post-names" connectorTagName="div" args=(hash user=this.user) tagName="div"}}
         </div>

--- a/app/assets/javascripts/discourse/app/templates/modal/user-status.hbs
+++ b/app/assets/javascripts/discourse/app/templates/modal/user-status.hbs
@@ -3,6 +3,19 @@
     <div class="control-group">
       {{user-status-picker emoji=emoji description=description}}
     </div>
+    <div class="control-group control-group-remove-status">
+      <label class="control-label">
+        {{i18n "user_status.remove_status"}}
+      </label>
+      {{time-shortcut-picker
+        timeShortcuts=timeShortcuts
+        hiddenOptions=hiddenTimeShortcutOptions
+        customLabels=customTimeShortcutLabels
+        prefilledDatetime=prefilledDateTime
+        onTimeSelected=(action "onTimeSelected")
+        _itsatrap=_itsatrap
+      }}
+    </div>
     <div class="modal-footer control-group">
       {{d-button
         label="user_status.save"

--- a/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
+++ b/app/assets/javascripts/discourse/app/widgets/quick-access-profile.js
@@ -4,6 +4,7 @@ import QuickAccessItem from "discourse/widgets/quick-access-item";
 import QuickAccessPanel from "discourse/widgets/quick-access-panel";
 import { createWidgetFrom } from "discourse/widgets/widget";
 import showModal from "discourse/lib/show-modal";
+import { dateNode } from "discourse/helpers/node";
 
 const _extraItems = [];
 
@@ -27,20 +28,11 @@ createWidgetFrom(QuickAccessItem, "user-status-item", {
   tagName: "li.user-status",
 
   html() {
-    const action = "hideMenuAndSetStatus";
-    const userStatus = this.currentUser.status;
-    if (userStatus) {
-      return this.attach("flat-button", {
-        action,
-        emoji: userStatus.emoji,
-        translatedLabel: userStatus.description,
-      });
+    const status = this.currentUser.status;
+    if (status) {
+      return this._editStatusButton(status);
     } else {
-      return this.attach("flat-button", {
-        action,
-        icon: "plus-circle",
-        label: "user_status.set_custom_status",
-      });
+      return this._setStatusButton();
     }
   },
 
@@ -50,6 +42,28 @@ createWidgetFrom(QuickAccessItem, "user-status-item", {
       title: "user_status.set_custom_status",
       modalClass: "user-status",
     });
+  },
+
+  _setStatusButton() {
+    return this.attach("flat-button", {
+      action: "hideMenuAndSetStatus",
+      icon: "plus-circle",
+      label: "user_status.set_custom_status",
+    });
+  },
+
+  _editStatusButton(status) {
+    const menuButton = {
+      action: "hideMenuAndSetStatus",
+      emoji: status.emoji,
+      translatedLabel: status.description,
+    };
+
+    if (status.ends_at) {
+      menuButton.contents = dateNode(status.ends_at);
+    }
+
+    return this.attach("flat-button", menuButton);
   },
 });
 

--- a/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/user-status-test.js
@@ -24,8 +24,9 @@ acceptance("User Status", function (needs) {
   const userStatus = "off to dentist";
   const userStatusEmoji = "tooth";
   const userId = 1;
+  const userTimezone = "UTC";
 
-  needs.user({ id: userId });
+  needs.user({ id: userId, timezone: userTimezone });
 
   needs.pretender((server, helper) => {
     server.put("/user-status.json", () => {
@@ -102,7 +103,11 @@ acceptance("User Status", function (needs) {
     this.siteSettings.enable_user_status = true;
 
     updateCurrentUser({
-      status: { description: userStatus, emoji: userStatusEmoji },
+      status: {
+        description: userStatus,
+        emoji: userStatusEmoji,
+        ends_at: "2100-02-01T09:35:00.000Z",
+      },
     });
 
     await visit("/");
@@ -118,6 +123,12 @@ acceptance("User Status", function (needs) {
       userStatus,
       "status description is shown"
     );
+    assert.equal(
+      query(".date-picker").value,
+      "2100-02-01",
+      "ends_at date is shown"
+    );
+    assert.equal(query(".time-input").value, "09:35", "ends_at time is shown");
   });
 
   test("emoji picking", async function (assert) {
@@ -213,6 +224,28 @@ acceptance("User Status", function (needs) {
     assert.notOk(exists(".header-dropdown-toggle .user-status-background"));
   });
 
+  test("setting user status with auto removing timer", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+
+    await visit("/");
+    await openUserStatusModal();
+
+    await fillIn(".user-status-description", userStatus);
+    await pickEmoji(userStatusEmoji);
+    await click("#tap_tile_one_hour");
+    await click(".btn-primary"); // save
+
+    await click(".header-dropdown-toggle.current-user");
+    await click(".menu-links-row .user-preferences-link");
+
+    assert.equal(
+      query("div.quick-access-panel li.user-status span.relative-date")
+        .innerText,
+      "1h",
+      "shows user status timer on the menu"
+    );
+  });
+
   test("it's impossible to set status without description", async function (assert) {
     this.siteSettings.enable_user_status = true;
 
@@ -237,7 +270,7 @@ acceptance("User Status", function (needs) {
     );
   });
 
-  test("shows actual status on the modal after canceling the modal", async function (assert) {
+  test("shows actual status on the modal after canceling the modal and opening it again", async function (assert) {
     this.siteSettings.enable_user_status = true;
 
     updateCurrentUser({

--- a/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
+++ b/app/assets/javascripts/discourse/tests/helpers/qunit-helpers.js
@@ -71,7 +71,12 @@ import {
 } from "discourse/lib/to-markdown";
 
 export function currentUser() {
-  return User.create(sessionFixtures["/session/current.json"].current_user);
+  const user = User.create(
+    sessionFixtures["/session/current.json"].current_user
+  );
+  user.appEvents = getOwner(this).lookup("service:appEvents");
+  user.trackStatus();
+  return user;
 }
 
 let _initialized = new Set();

--- a/app/assets/stylesheets/common/base/discourse.scss
+++ b/app/assets/stylesheets/common/base/discourse.scss
@@ -447,6 +447,14 @@ table {
   }
 }
 
+.user-menu .quick-access-panel li.user-status .relative-date {
+  text-align: left;
+  font-size: $font-down-3;
+  padding-top: 0.45em;
+  margin-left: 0.75em;
+  color: var(--primary-medium);
+}
+
 .user-menu .quick-access-panel li.do-not-disturb {
   display: flex;
   flex: 0 0 100%;

--- a/app/assets/stylesheets/common/components/user-card.scss
+++ b/app/assets/stylesheets/common/components/user-card.scss
@@ -302,7 +302,18 @@ $avatar_margin: -50px; // negative margin makes avatars extend above cards
 }
 
 h3.user-status {
+  display: flex;
+
   img.emoji {
     margin-bottom: 1px;
+    margin-right: 0.3em;
+  }
+
+  .relative-date {
+    text-align: left;
+    font-size: $font-down-3;
+    padding-top: 0.5em;
+    margin-left: 0.6em;
+    color: var(--primary-medium);
   }
 }

--- a/app/assets/stylesheets/common/modal/user-status.scss
+++ b/app/assets/stylesheets/common/modal/user-status.scss
@@ -22,5 +22,13 @@
     @media (max-width: 600px) {
       width: 100%;
     }
+
+    .control-group-remove-status {
+      margin-top: 25px;
+    }
+
+    .control-label {
+      font-weight: 700;
+    }
   }
 }

--- a/app/controllers/user_status_controller.rb
+++ b/app/controllers/user_status_controller.rb
@@ -8,7 +8,7 @@ class UserStatusController < ApplicationController
     description = params.require(:description)
     emoji = params.require(:emoji)
 
-    current_user.set_status!(description, emoji)
+    current_user.set_status!(description, emoji, params[:ends_at])
     render json: success_json
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -662,9 +662,15 @@ class User < ActiveRecord::Base
   end
 
   def publish_user_status(status)
-    payload = status ?
-                { description: status.description, emoji: status.emoji } :
-                nil
+    if status
+      payload = {
+        description: status.description,
+        emoji: status.emoji,
+        ends_at: status.ends_at&.iso8601
+      }
+    else
+      payload = nil
+    end
 
     MessageBus.publish("/user-status/#{id}", payload, user_ids: [id])
   end
@@ -1522,20 +1528,18 @@ class User < ActiveRecord::Base
     publish_user_status(nil)
   end
 
-  def set_status!(description, emoji)
-    now = Time.zone.now
+  def set_status!(description, emoji, ends_at)
+    status = {
+      description: description,
+      emoji: emoji,
+      set_at: Time.zone.now,
+      ends_at: ends_at
+    }
+
     if user_status
-      user_status.update!(
-        description: description,
-        emoji: emoji,
-        set_at: now)
+      user_status.update!(status)
     else
-      self.user_status = UserStatus.create!(
-        user_id: id,
-        description: description,
-        emoji: emoji,
-        set_at: now
-      )
+      self.user_status = UserStatus.create!(status)
     end
 
     publish_user_status(user_status)

--- a/app/models/user_status.rb
+++ b/app/models/user_status.rb
@@ -6,6 +6,10 @@ class UserStatus < ActiveRecord::Base
   validate :ends_at_greater_than_set_at,
            if: Proc.new { |t| t.will_save_change_to_set_at? || t.will_save_change_to_ends_at? }
 
+  def expired?
+    ends_at && ends_at < Time.zone.now
+  end
+
   def ends_at_greater_than_set_at
     if ends_at && set_at > ends_at
       errors.add(:ends_at, I18n.t("user_status.errors.ends_at_should_be_greater_than_set_at"))

--- a/app/serializers/current_user_serializer.rb
+++ b/app/serializers/current_user_serializer.rb
@@ -313,7 +313,7 @@ class CurrentUserSerializer < BasicUserSerializer
   end
 
   def include_status?
-    SiteSetting.enable_user_status
+    SiteSetting.enable_user_status && object.user_status && !object.user_status.expired?
   end
 
   def status

--- a/app/serializers/user_card_serializer.rb
+++ b/app/serializers/user_card_serializer.rb
@@ -224,7 +224,7 @@ class UserCardSerializer < BasicUserSerializer
   end
 
   def include_status?
-    SiteSetting.enable_user_status
+    SiteSetting.enable_user_status && user.user_status && !user.user_status.expired?
   end
 
   def status

--- a/app/serializers/user_status_serializer.rb
+++ b/app/serializers/user_status_serializer.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 class UserStatusSerializer < ApplicationSerializer
-  attributes :description, :emoji
+  attributes :description, :emoji, :ends_at
 end

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -644,6 +644,8 @@ en:
 
     time_shortcut:
       now: "Now"
+      in_one_hour: "In one hour"
+      in_two_hours: "In two hours"
       later_today: "Later today"
       two_days: "Two days"
       next_business_day: "Next business day"
@@ -664,6 +666,7 @@ en:
       forever: "Forever"
       relative: "Relative time"
       none: "None needed"
+      never: "Never"
       last_custom: "Last custom datetime"
       custom: "Custom date and time"
       select_timeframe: "Select a timeframe"
@@ -1789,6 +1792,7 @@ en:
       save: "Save"
       set_custom_status: "Set custom status"
       what_are_you_doing: "What are you doing?"
+      remove_status: "Remove status"
 
     loading: "Loading..."
     errors:

--- a/spec/requests/user_status_controller_spec.rb
+++ b/spec/requests/user_status_controller_spec.rb
@@ -84,7 +84,7 @@ describe UserStatusController do
       it "publishes to message bus" do
         status = "off to dentist"
         emoji = "tooth"
-        ends_at = DateTime.parse("2100-01-01 18:00")
+        ends_at = "2100-01-01T18:00:00Z"
 
         messages = MessageBus.track_publish do
           put "/user-status.json", params: {
@@ -100,7 +100,7 @@ describe UserStatusController do
 
         expect(messages[0].data[:description]).to eq(status)
         expect(messages[0].data[:emoji]).to eq(emoji)
-        expect(messages[0].data[:endsAt]).to eq(ends_at)
+        expect(messages[0].data[:ends_at]).to eq(ends_at)
       end
     end
   end

--- a/spec/requests/user_status_controller_spec.rb
+++ b/spec/requests/user_status_controller_spec.rb
@@ -38,38 +38,69 @@ describe UserStatusController do
       it "sets user status" do
         status = "off to dentist"
         status_emoji = "tooth"
-        put "/user-status.json", params: { description: status, emoji: status_emoji }
+        ends_at = DateTime.parse("2100-01-01 18:00")
+
+        put "/user-status.json", params: {
+          description: status,
+          emoji: status_emoji,
+          ends_at: ends_at
+        }
+
+        puts user.user_status.ends_at
+
         expect(user.user_status.description).to eq(status)
         expect(user.user_status.emoji).to eq(status_emoji)
+        expect(user.user_status.ends_at).to eq_time(ends_at)
       end
 
       it "following calls update status" do
         status = "off to dentist"
         status_emoji = "tooth"
-        put "/user-status.json", params: { description: status, emoji: status_emoji }
+        ends_at = DateTime.parse("2100-01-01 18:00")
+        put "/user-status.json", params: {
+          description: status,
+          emoji: status_emoji,
+          ends_at: ends_at
+        }
         user.reload
         expect(user.user_status.description).to eq(status)
         expect(user.user_status.emoji).to eq(status_emoji)
+        expect(user.user_status.ends_at).to eq_time(ends_at)
 
         new_status = "surfing"
         new_status_emoji = "surfing_man"
-        put "/user-status.json", params: { description: new_status, emoji: new_status_emoji }
+        new_ends_at = DateTime.parse("2100-01-01 18:59")
+        put "/user-status.json", params: {
+          description: new_status,
+          emoji: new_status_emoji,
+          ends_at: new_ends_at
+        }
         user.reload
         expect(user.user_status.description).to eq(new_status)
         expect(user.user_status.emoji).to eq(new_status_emoji)
+        expect(user.user_status.ends_at).to eq_time(new_ends_at)
       end
 
       it "publishes to message bus" do
         status = "off to dentist"
         emoji = "tooth"
+        ends_at = DateTime.parse("2100-01-01 18:00")
+
         messages = MessageBus.track_publish do
-          put "/user-status.json", params: { description: status, emoji: emoji }
+          put "/user-status.json", params: {
+            description: status,
+            emoji: emoji,
+            ends_at: ends_at
+          }
         end
 
         expect(messages.size).to eq(1)
         expect(messages[0].channel).to eq("/user-status/#{user.id}")
-        expect(messages[0].data[:description]).to eq(status)
         expect(messages[0].user_ids).to eq([user.id])
+
+        expect(messages[0].data[:description]).to eq(status)
+        expect(messages[0].data[:emoji]).to eq(emoji)
+        expect(messages[0].data[:endsAt]).to eq(ends_at)
       end
     end
   end

--- a/spec/serializers/current_user_serializer_spec.rb
+++ b/spec/serializers/current_user_serializer_spec.rb
@@ -190,7 +190,7 @@ RSpec.describe CurrentUserSerializer do
     fab!(:user) { Fabricate(:user, user_status: user_status) }
     let(:serializer) { described_class.new(user, scope: Guardian.new(user), root: false) }
 
-    it "serializes when enabled" do
+    it "adds user status when enabled" do
       SiteSetting.enable_user_status = true
 
       json = serializer.as_json
@@ -201,9 +201,29 @@ RSpec.describe CurrentUserSerializer do
       end
     end
 
-    it "doesn't serialize when disabled" do
+    it "doesn't add user status when disabled" do
       SiteSetting.enable_user_status = false
       json = serializer.as_json
+      expect(json.keys).not_to include :status
+    end
+
+    it "doesn't add expired user status" do
+      SiteSetting.enable_user_status = true
+
+      user.user_status.ends_at = 1.minutes.ago
+      serializer = described_class.new(user, scope: Guardian.new(user), root: false)
+      json = serializer.as_json
+
+      expect(json.keys).not_to include :status
+    end
+
+    it "doesn't return status if user doesn't have it set" do
+      SiteSetting.enable_user_status = true
+
+      user.clear_status!
+      user.reload
+      json = serializer.as_json
+
       expect(json.keys).not_to include :status
     end
   end


### PR DESCRIPTION
- CLIENT: add time shortcut picker
- Acceptance test
- CLIENT: show timer on the menu button
- CLIENT: show timer on the menu button
- CLIENT: sending the endsAt value to the server
- SERVER: saving the endsAt value
- CLIENT: sending the endsAt value to the server
- SERVER: saving the endsAt value
- CLIENT: handle empty ends_at value
- ACCEPTANCE TEST: prefill the ends_at date on the modal
- SERVER: take care of dates correctness
- CLIENT: prefill the endsAt date on the modal
- ACCEPTANCE TEST
- CLIENT: showing duration - in progress
- SERVER: ends_at instead of endsAt
- CLIENT: ends_at instead of endsAt
- ACCEPTANCE TEST: ends_at instead of endsAt
- CLIENT: ends_at instead of endsAt
- SERVER: add ends_at to the serializer
- CLIENT: format remaining time on the header menu
- CLIENT: show ends_at date on the user card
- CLIENT: status auto clearing - in progress
- SERVER: don't send expired status to the client
- CLIENT: add a test for auto clearing of status
- SERVER: fix checking if status is expired
- CLIENT: use @observer
- CLIENT: more accurate name for the user-status-changed app event
- ACCEPTANCE TESTS: correct ends_at
- Debugging

<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
