### PR TITLE
FIX: do not show user status on posts twice

### DIFF
--- a/app/assets/javascripts/discourse/app/widgets/poster-name.js
+++ b/app/assets/javascripts/discourse/app/widgets/poster-name.js
@@ -122,7 +122,9 @@ export default createWidget("poster-name", {
       }
     }
 
-    const afterNameContents = this.afterNameContents(attrs);
+    const afterNameContents =
+      applyDecorators(this, "after-name", attrs, this.state) || [];
+
     nameContents = nameContents.concat(afterNameContents);
 
     const contents = [
@@ -160,19 +162,16 @@ export default createWidget("poster-name", {
       );
     }
 
+    if (this.siteSettings.enable_user_status) {
+      this.addUserStatus(contents, attrs);
+    }
+
     return contents;
   },
 
-  afterNameContents(attrs) {
-    const contents = [];
-    if (
-      this.siteSettings.enable_user_status &&
-      attrs.user &&
-      attrs.user.status
-    ) {
+  addUserStatus(contents, attrs) {
+    if (attrs.user && attrs.user.status) {
       contents.push(this.attach("post-user-status", attrs.user.status));
     }
-    contents.push(...applyDecorators(this, "after-name", attrs, this.state));
-    return contents;
   },
 });

--- a/app/assets/javascripts/discourse/tests/acceptance/topic-user-status-test.js
+++ b/app/assets/javascripts/discourse/tests/acceptance/topic-user-status-test.js
@@ -19,6 +19,10 @@ acceptance("Topic - User Status", function (needs) {
       const response = cloneJSON(TopicFixtures["/t/299/1.json"]);
       response.post_stream.posts.forEach((post) => {
         post.user_status = status;
+
+        // we need the poster's name to be different from username
+        // so when display_name_on_posts = true, both name and username will be shown:
+        post.name = "Evil T";
       });
 
       return helper.response(200, response);
@@ -27,6 +31,19 @@ acceptance("Topic - User Status", function (needs) {
 
   test("shows user status next to avatar on posts", async function (assert) {
     this.siteSettings.enable_user_status = true;
+    await visit("/t/-/299/1");
+
+    assert.equal(
+      queryAll(".topic-post .user-status-message").length,
+      3,
+      "all posts has user status"
+    );
+  });
+
+  test("shows user status next to avatar on posts when displaying names on posts is enabled", async function (assert) {
+    this.siteSettings.enable_user_status = true;
+    this.siteSettings.display_name_on_posts = true;
+
     await visit("/t/-/299/1");
 
     assert.equal(

--- a/app/assets/stylesheets/common/base/topic-post.scss
+++ b/app/assets/stylesheets/common/base/topic-post.scss
@@ -78,10 +78,6 @@ $quote-share-maxwidth: 150px;
   .user-title a {
     color: var(--primary-med-or-secondary-med);
   }
-
-  .user-status-message {
-    margin-left: 0.3em;
-  }
 }
 
 // global styles for the cooked HTML content in posts (and preview)


### PR DESCRIPTION
<!-- NOTE: All pull requests should have tests (rspec in Ruby, qunit in JavaScript). If your code does not include test coverage, please include an explanation of why it was omitted. -->
